### PR TITLE
Clarify that C and Fortran support comlex types in reductions.

### DIFF
--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -213,7 +213,7 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     restored to the original values.
 
     The sum and product reduction routines include complex-typed interfaces
-    for the \Cstd API only.
+    for the \Cstd and \Fortran API only.
     When the \Cstd translation environment does not support complex types%
     \footnote{That is, under \Cstd language standards prior to \Cstd[99] or
       under \Cstd[11] when \CONST{\_\_STDC\_NO\_COMPLEX\_\_} is defined to 1},


### PR DESCRIPTION
There seems to be a small inconcistency in the API description for the reduction operations. 
I talked to @nspark, and it seems to be reasonable to clarify that the complex-typed interfaces are supported by C and Fortran.