### PR TITLE
Post-RC1 changes

### DIFF
--- a/content/collective_intro.tex
+++ b/content/collective_intro.tex
@@ -3,8 +3,8 @@ operations on a group of \acp{PE} called an active set. The collective
 routines require all \acp{PE} in the active set to simultaneously call the
 routine.  A \ac{PE} that is not in the active set calling the collective
 routine results in undefined behavior.  All collective routines have an
-active set as an input parameter except \FUNC{shmem\_barrier\_all};
-\FUNC{shmem\_barrier\_all} must be called by all \acp{PE} of the
+active set as an input parameter except \FUNC{shmem\_barrier\_all} and \FUNC{shmem\_sync\_all}.
+Both \FUNC{shmem\_barrier\_all} and \FUNC{shmem\_sync\_all} must be called by all \acp{PE} of the
 \openshmem program. 
 
 The active set is defined by the arguments \VAR{PE\_start}, \VAR{logPE\_stride},
@@ -21,7 +21,7 @@ restored to its original contents.  The user is permitted to reuse a \VAR{pSync}
 array if all previous collective routines using the \VAR{pSync} array have been
 completed by all participating \acp{PE}.  One can use a synchronization
 collective routine such as \FUNC{shmem\_barrier} to ensure completion of previous collective
-routines. The \FUNC{shmem\_barrier} routine allows the same \VAR{pSync} array to
+routines. The \FUNC{shmem\_barrier} and \FUNC{shmem\_sync} routines allow the same \VAR{pSync} array to
 be used on consecutive calls as long as the \acp{PE} in the active set do not change. 
 
 All collective routines defined in the specification are blocking.  The
@@ -31,6 +31,8 @@ the \openshmem specification are:
 \begin{itemize}
 \item \FUNC{shmem\_barrier\_all}
 \item \FUNC{shmem\_barrier}
+\item \FUNC{shmem\_sync\_all}
+\item \FUNC{shmem\_sync}
 \item \FUNC{shmem\_broadcast\{32, 64\}}
 \item \FUNC{shmem\_collect\{32, 64\}}
 \item \FUNC{shmem\_fcollect\{32, 64\}}

--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -73,13 +73,15 @@ CALL SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     \VAR{dest} and \VAR{source} data objects, and the same \VAR{pSync} work
     array must be passed to all \acp{PE} in the active set.
 
-    Before any \ac{PE} calls a \FUNC{shmem\_alltoall} routine, the following
-    conditions must exist (synchronization via a barrier or some other method is
-    often needed to ensure this): The \VAR{pSync} array on all \acp{PE} in the
-    active set is not still in use from a prior call to a
-    \FUNC{shmem\_alltoall/s} routine.  The \VAR{dest} data object on
-    all \acp{PE} in the active set is ready to accept the
-    \FUNC{shmem\_alltoall} data.
+    Before any \ac{PE} calls a \FUNC{shmem\_alltoall} routine,
+    the following conditions must be ensured:
+    \begin{itemize}
+    \item The \VAR{pSync} array on all \acp{PE} in the active set is not
+      still in use from a prior call to a \FUNC{shmem\_alltoall} routine.
+    \item The \VAR{dest} data object on all \acp{PE} in the active set is
+      ready to accept the \FUNC{shmem\_alltoall} data.
+    \end{itemize}
+    Otherwise, the behavior is undefined.
 
     Upon return from a \FUNC{shmem\_alltoall} routine, the following is true for
     the local PE: Its \VAR{dest} symmetric data object is completely updated and

--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -65,8 +65,8 @@ CALL SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
 
     As with all \openshmem collective routines, this routine assumes
     that only \acp{PE} in the active set call the routine.  If a \ac{PE} not
-    in the active set calls an \openshmem collective routine, undefined
-    behavior results.
+    in the active set calls an \openshmem collective routine,
+    the behavior is undefined.
 
     The values of arguments \VAR{nelems}, \VAR{PE\_start}, \VAR{logPE\_stride},
     and \VAR{PE\_size} must be equal on all \acp{PE} in the active set. The same

--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -37,13 +37,13 @@ CALL SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
 \apiargument{IN}{PE\_size}{The number of \acp{PE} in the active set.
     \VAR{PE\_size} must be of type integer.  When using \Fortran, it must
     be a default integer value.}
-\apiargument{IN}{pSync}{A symmetric work array. In \CorCpp, \VAR{pSync} must be
-    of type long and size \CONST{SHMEM\_ALLTOALL\_SYNC\_SIZE}. In \Fortran,
-    \VAR{pSync} must be of type integer and size
-    \CONST{SHMEM\_ALLTOALL\_SYNC\_SIZE}.  When using \Fortran, it must be a
-    default integer value. Every element of this array must be initialized with
-    the value \CONST{SHMEM\_SYNC\_VALUE} before any of the \acp{PE} in the
-    active set enter the routine.}
+\apiargument{IN}{pSync}{
+    A symmetric work array of size \CONST{SHMEM\_ALLTOALL\_SYNC\_SIZE}.
+    In \CorCpp, \VAR{pSync} must be an array of elements of type \CTYPE{long}.
+    In \Fortran, \VAR{pSync} must be an array of elements of default integer type.
+    Every element of this array must be initialized with the value
+    \CONST{SHMEM\_SYNC\_VALUE} before any of the \acp{PE} in the active set
+    enter the routine.}
 
 \end{apiarguments}
 

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -48,13 +48,13 @@ CALL SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, P
 \apiargument{IN}{PE\_size}{The number of \acp{PE} in the active set.
     \VAR{PE\_size} must be of type integer.  When using \Fortran, it must
     be a default integer value.}
-\apiargument{IN}{pSync}{A symmetric work array. In \CorCpp, \VAR{pSync} must be
-    of type long and size \CONST{SHMEM\_ALLTOALLS\_SYNC\_SIZE}. In \Fortran,
-    \VAR{pSync} must be of type integer and size
-    \CONST{SHMEM\_ALLTOALLS\_SYNC\_SIZE}.  When using \Fortran, it must be a
-    default integer value. Every element of this array must be initialized with
-    the value \CONST{SHMEM\_SYNC\_VALUE} before any of the \acp{PE} in the
-    active set enter the routine.}
+\apiargument{IN}{pSync}{
+    A symmetric work array of size \CONST{SHMEM\_ALLTOALLS\_SYNC\_SIZE}.
+    In \CorCpp, \VAR{pSync} must be an array of elements of type \CTYPE{long}.
+    In \Fortran, \VAR{pSync} must be an array of elements of default integer type.
+    Every element of this array must be initialized with the value
+    \CONST{SHMEM\_SYNC\_VALUE} before any of the \acp{PE} in the active set
+    enter the routine.}
     
 \end{apiarguments}
 

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -79,15 +79,17 @@ CALL SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, P
     \VAR{logPE\_stride}, and \VAR{PE\_size} must be equal on all \acp{PE} in the
     active set. The same \VAR{dest} and \VAR{source} data objects, and the same
     \VAR{pSync} work array must be passed to all \acp{PE} in the active set.
-    
-    Before any \ac{PE} calls to a \FUNC{shmem\_alltoalls} routine, the following
-    conditions must exist (synchronization via a barrier or some other method is
-    often needed to ensure this): The \VAR{pSync} array on all \acp{PE} in the
-    active set is not still in use from a prior call to a
-    \FUNC{shmem\_alltoalls} routine.  The \VAR{dest} data object on
-    all \acp{PE} in the active set is ready to accept the
-    \FUNC{shmem\_alltoalls} data.
-    
+
+    Before any \ac{PE} calls a \FUNC{shmem\_alltoalls} routine,
+    the following conditions must be ensured:
+    \begin{itemize}
+    \item The \VAR{pSync} array on all \acp{PE} in the active set is not
+      still in use from a prior call to a \FUNC{shmem\_alltoall} routine.
+    \item The \VAR{dest} data object on all \acp{PE} in the active set is
+      ready to accept the \FUNC{shmem\_alltoalls} data.
+    \end{itemize}
+    Otherwise, the behavior is undefined.
+
     Upon return from a \FUNC{shmem\_alltoalls} routine, the following is true for
     the local PE: Its \VAR{dest} symmetric data object is completely updated and
     the data has been copied out of the \VAR{source} data object.

--- a/content/shmem_barrier.tex
+++ b/content/shmem_barrier.tex
@@ -63,9 +63,10 @@ CALL SHMEM_BARRIER(PE_start, logPE_stride, PE_size, pSync)
 }
 
 \apinotes{
-    If the \VAR{pSync} array is initialized at run time, another method of
-    synchronization (e.g., \FUNC{shmem\_barrier\_all}) must be used before
-    the initial use of that \VAR{pSync} array by \FUNC{shmem\_barrier}.
+    If the \VAR{pSync} array is initialized at the run time, all
+    \acp{PE} must be synchronized before the first call to \FUNC{shmem\_barrier}
+    (e.g., by \FUNC{shmem\_barrier\_all}) to ensure the array has been initialized
+    by all \acp{PE} before it is used.
     
     If  the active set does not change, \FUNC{shmem\_barrier} can  be called
     repeatedly with the same \VAR{pSync} array.  No additional synchronization

--- a/content/shmem_barrier.tex
+++ b/content/shmem_barrier.tex
@@ -26,10 +26,11 @@ CALL SHMEM_BARRIER(PE_start, logPE_stride, PE_size, pSync)
 \apiargument{IN}{PE\_size}{The number of  \acp{PE} in the active set.  \VAR{PE\_size}
     must be of type integer.  When using  \Fortran, it must be a default
     integer value.}
-\apiargument{IN}{pSync}{A symmetric work array. In \CorCpp, \VAR{pSync} must
-    be of type long and size \CONST{SHMEM\_BARRIER\_SYNC\_SIZE}.  In \Fortran,
-    \VAR{pSync} must be of type integer and size \CONST{SHMEM\_BARRIER\_SYNC\_SIZE}.
-    When using \Fortran, it must  be a default  integer type.  Every element
+\apiargument{IN}{pSync}{
+    A symmetric work array of size \CONST{SHMEM\_BARRIER\_SYNC\_SIZE}.
+    In \CorCpp, \VAR{pSync} must be an array of elements of type \CTYPE{long}.
+    In \Fortran, \VAR{pSync} must be an array of elements of default integer type.
+    Every element
     of this array must be initialized to \CONST{SHMEM\_SYNC\_VALUE} before any of
     the \acp{PE} in the active set enter \FUNC{shmem\_barrier} the first time.}
 

--- a/content/shmem_barrier.tex
+++ b/content/shmem_barrier.tex
@@ -63,9 +63,9 @@ CALL SHMEM_BARRIER(PE_start, logPE_stride, PE_size, pSync)
 }
 
 \apinotes{
-    If the \VAR{pSync} array is initialized at run time, be sure to use some type of
-    synchronization, for example, a call to \FUNC{shmem\_barrier\_all}, before
-    calling \FUNC{shmem\_barrier} for the first time.
+    If the \VAR{pSync} array is initialized at run time, another method of
+    synchronization (e.g., \FUNC{shmem\_barrier\_all}) must be used before
+    the initial use of that \VAR{pSync} array by \FUNC{shmem\_barrier}.
     
     If  the active set does not change, \FUNC{shmem\_barrier} can  be called
     repeatedly with the same \VAR{pSync} array.  No additional synchronization

--- a/content/shmem_barrier.tex
+++ b/content/shmem_barrier.tex
@@ -54,7 +54,7 @@ CALL SHMEM_BARRIER(PE_start, logPE_stride, PE_size, pSync)
     \acp{PE} in the active set on the default context are complete before returning.
     
     The  same  \VAR{pSync} array may be reused on consecutive calls   to
-    \FUNC{shmem\_barrier} if the same active \ac{PE} set is used.
+    \FUNC{shmem\_barrier} if the same active set is used.
 }
 
 \apireturnvalues{

--- a/content/shmem_barrier.tex
+++ b/content/shmem_barrier.tex
@@ -82,7 +82,7 @@ CALL SHMEM_BARRIER(PE_start, logPE_stride, PE_size, pSync)
 \begin{apiexamples}
 
 \apicexample
-	{The following barrier example is for C11 programs:}
+	{The following barrier example is for \Cstd[11] programs:}
 	{./example_code/shmem_barrier_example.c}
 	{}
 

--- a/content/shmem_barrier.tex
+++ b/content/shmem_barrier.tex
@@ -43,7 +43,7 @@ CALL SHMEM_BARRIER(PE_start, logPE_stride, PE_size, pSync)
     
     As with all \openshmem collective routines, each of these routines assumes that
     only \acp{PE} in the active set call the routine.  If a \ac{PE} not  in  the
-    active set calls an \openshmem collective routine, undefined behavior results.
+    active set calls an \openshmem collective routine, the behavior is undefined.
     
     The values of arguments \VAR{PE\_start}, \VAR{logPE\_stride}, and \VAR{PE\_size}
     must be the same value on all \acp{PE} in the active set.  The same work array must be

--- a/content/shmem_barrier_all.tex
+++ b/content/shmem_barrier_all.tex
@@ -52,7 +52,7 @@ CALL SHMEM_BARRIER_ALL
 \begin{apiexamples}
 
 \apicexample
-    { The following \FUNC{shmem\_barrier\_all} example is for C11 programs:}
+    { The following \FUNC{shmem\_barrier\_all} example is for \Cstd[11] programs:}
     {./example_code/shmem_barrierall_example.c}
     {} 
 

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -66,17 +66,25 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
     \dest{} and \source{} data objects and the same \VAR{pSync} work array must be
     passed by all \acp{PE} in the active set.
     
-    Before any \ac{PE} calls a broadcast routine, the following
-    conditions must be met: (synchronization via a barrier or some other method is often
-    needed to ensure this): The \VAR{pSync} array on all \acp{PE} in the
-    active set is not still in use from a prior call to a broadcast routine.  The
-    \dest{} array on all \acp{PE} in the active set is ready to accept the
-    broadcast data.
+    Before any \ac{PE} calls a broadcast routine,
+    the following conditions must be ensured:
+    \begin{itemize}
+    \item The \VAR{pSync} array on all \acp{PE} in the active set is
+      not still in use from a prior call to a broadcast routine.
+    \item The \dest{} array on all \acp{PE} in the active set is ready
+      to accept the broadcast data.
+    \end{itemize}
+    Otherwise, the behavior is undefined.
     
     Upon return from a broadcast routine, the following are true for the local
-    \ac{PE}: If the current \ac{PE} is not the root \ac{PE}, the \dest{} data object
-    is updated. The \source{} data object may be safely reused.  
-    The values in the \VAR{pSync} array are restored to the original values.
+    \ac{PE}:
+    \begin{itemize}
+    \item If the current \ac{PE} is not the root \ac{PE},
+      the \dest{} data object is updated.
+    \item The \source{} data object may be safely reused.
+    \item The values in the \VAR{pSync} array are restored to the
+      original values.
+    \end{itemize}
 }
 
 \apidesctable{

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -40,13 +40,13 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
 \apiargument{IN}{PE\_size}{ The number of \acp{PE} in the active set.
     \VAR{PE\_size} must be of type integer.  When using \Fortran, it must be a
     default integer value.}
-\apiargument{IN}{pSync}{ A symmetric work array.  In \CorCpp, \VAR{pSync} must
-    be of type long and size \CONST{SHMEM\_BCAST\_SYNC\_SIZE}. In \Fortran,
-    \VAR{pSync} must be of type integer and size \CONST{SHMEM\_BCAST\_SYNC\_SIZE}.
+\apiargument{IN}{pSync}{
+    A symmetric work array of size \CONST{SHMEM\_BCAST\_SYNC\_SIZE}.
+    In \CorCpp, \VAR{pSync} must be an array of elements of type \CTYPE{long}.
+    In \Fortran, \VAR{pSync} must be an array of elements of default integer type.
     Every element of this array must be initialized with the value
-    \CONST{SHMEM\_SYNC\_VALUE} (in \CorCpp) or \CONST{SHMEM\_SYNC\_VALUE} (in
-    \Fortran) before any of the \acp{PE}  in  the  active set enter
-    \FUNC{shmem\_broadcast}.}
+    \CONST{SHMEM\_SYNC\_VALUE} before any of the \acp{PE} in the active set
+    enters \FUNC{shmem\_broadcast}.}
 
 \end{apiarguments}
 

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -59,7 +59,7 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
     
     As with all \openshmem collective routines, each of these routines assumes that
     only \acp{PE} in the active set call the routine.  If a \ac{PE} not in the
-   active set calls an \openshmem collective routine, undefined behavior results.
+    active set calls an \openshmem collective routine, the behavior is undefined.
     
     The values of arguments \VAR{PE\_root}, \VAR{PE\_start}, \VAR{logPE\_stride},
     and \VAR{PE\_size} must be the same value on all \acp{PE} in the active set.  The same

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -51,13 +51,13 @@ CALL SHMEM_FCOLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
 \apiargument{IN}{PE\_size}{The number of \acp{PE} in the active set. \VAR{PE\_size}
     must be of type integer.  When using  \Fortran, it must be a default
     integer value.}
-\apiargument{IN}{pSync}{A symmetric  work array.  In \CorCpp, \VAR{pSync} must be of
-    type long and size \CONST{SHMEM\_COLLECT\_SYNC\_SIZE}.  In \Fortran,
-    \VAR{pSync} must be of type integer and size \CONST{SHMEM\_COLLECT\_SYNC\_SIZE}.
-    When using \Fortran, it must be a default integer value.  Every element of
-    this array must be initialized with the value \CONST{SHMEM\_SYNC\_VALUE} in
-    \CorCpp{} or \CONST{SHMEM\_SYNC\_VALUE} in \Fortran before any of the \acp{PE}
-    in the active set enter \FUNC{shmem\_collect} or \FUNC{shmem\_fcollect}.}
+\apiargument{IN}{pSync}{
+    A symmetric work array of size \CONST{SHMEM\_COLLECT\_SYNC\_SIZE}.
+    In \CorCpp, \VAR{pSync} must be an array of elements of type \CTYPE{long}.
+    In \Fortran, \VAR{pSync} must be an array of elements of default integer type.
+    Every element of this array must be initialized with the value
+    \CONST{SHMEM\_SYNC\_VALUE} before any of the \acp{PE} in the active set
+    enter \FUNC{shmem\_collect} or \FUNC{shmem\_fcollect}.}
 
 \end{apiarguments}
 

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -193,13 +193,17 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     \VAR{PE\_size} must be equal on all \acp{PE} in the active set. The same \dest{}
     and \source{} arrays, and the same \VAR{pWrk} and \VAR{pSync} work arrays, must
     be passed to all \acp{PE} in the active set.
-    %FIXME: Reword 'the following conditions must be met.'
-    Before any \ac{PE} calls a reduction routine, the
-    following conditions must be met (synchronization via a \OPR{barrier} or some other
-    method is often needed to ensure this): The \VAR{pWrk} and \VAR{pSync} arrays
-    on all \acp{PE} in the active set are not still in use from a prior call to a
-    collective \openshmem routine.  The \dest{} array on all \acp{PE} in the
-    active set is ready to accept the results of the \OPR{reduction}.
+
+    Before any \ac{PE} calls a reduction routine,
+    the following conditions must be ensured:
+    \begin{itemize}
+    \item The \VAR{pWrk} and \VAR{pSync} arrays on all \acp{PE} in the
+      active set are not still in use from a prior call to a collective
+      \openshmem routine.
+    \item The \dest{} array on all \acp{PE} in the active set is ready
+      to accept the results of the \OPR{reduction}.
+    \end{itemize}
+    Otherwise, the behavior is undefined.
 
     Upon return from a reduction routine, the following are true for the local
     \ac{PE}: The \dest{} array is updated and the \source{} array may be safely reused.

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -188,8 +188,7 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
 
     As with all \openshmem collective routines, each of these routines assumes
     that only \acp{PE} in the active set call the routine.  If a \ac{PE} not in
-    the active set calls an \openshmem collective routine, undefined behavior
-    results.
+    the active set calls an \openshmem collective routine, the behavior is undefined.
 
     The values of arguments \VAR{nreduce}, \VAR{PE\_start}, \VAR{logPE\_stride}, and
     \VAR{PE\_size} must be equal on all \acp{PE} in the active set. The same \dest{}

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -123,7 +123,7 @@ CALL SHMEM_INT8_OR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size
 \end{Fsynopsis}
 
 \paragraph{XOR}
-Performs a bitwise EXCLUSIVE OR reduction across a set of \acp{PE}.\newline
+Performs a bitwise exclusive OR (XOR) reduction across a set of \acp{PE}.\newline
 \begin{Csynopsis}
 void shmem_short_xor_to_all(short *dest, const short *source, int nreduce, int PE_start, int logPE_stride, int PE_size, short *pWrk, long *pSync);
 void shmem_int_xor_to_all(int *dest, const int *source, int nreduce, int PE_start, int logPE_stride, int PE_size, int *pWrk, long *pSync);

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -206,8 +206,8 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     The values in the \VAR{pSync} array are
     restored to the original values.
 
-    The sum and product reduction routines include complex-typed
-    interfaces for the \Cstd API only. When the \Cstd translation
+    The complex-typed interfaces are only provided for sum and product
+    reductions. When the \Cstd translation
     environment does not support complex types\footnote{That is, under
     \Cstd language standards prior to \Cstd[99] or under \Cstd[11] when
     \CONST{\_\_STDC\_NO\_COMPLEX\_\_} is defined to 1}, an \openshmem

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -157,18 +157,17 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
 \apiargument{IN}{PE\_size}{The number of \acp{PE} in the active set.
     \VAR{PE\_size} must be of type integer.  When using \Fortran, it must be a
     default integer value.}
-\apiargument{IN}{pWrk}{A symmetric work array. The \VAR{pWrk} argument must have the
-    same data type as \dest. In \CorCpp, this contains max(\VAR{nreduce}/2 + 1,
-    \CONST{SHMEM\_REDUCE\_MIN\_WRKDATA\_SIZE}) elements. In \Fortran, this
-    contains max(\VAR{nreduce}/2 + 1, \CONST{SHMEM\_REDUCE\_MIN\_WRKDATA\_SIZE})
+\apiargument{IN}{pWrk}{
+    A symmetric work array of size at least
+    max(\VAR{nreduce}/2 + 1, \CONST{SHMEM\_REDUCE\_MIN\_WRKDATA\_SIZE})
     elements.}
-\apiargument{IN}{pSync}{A symmetric work array. In \CorCpp, \VAR{pSync} must be of
-    type long and size \CONST{SHMEM\_REDUCE\_SYNC\_SIZE}. In \Fortran, \VAR{pSync}
-    must be of type integer and size \CONST{SHMEM\_REDUCE\_SYNC\_SIZE}.  When
-    using \Fortran, it must be a default integer value. Every element of this array
-    must be initialized with the value \CONST{SHMEM\_SYNC\_VALUE} (in \CorCpp) or
-    \CONST{SHMEM\_SYNC\_VALUE} (in \Fortran) before any of the \acp{PE} in the
-    active set enter the reduction routine.}
+\apiargument{IN}{pSync}{
+    A symmetric work array of size \CONST{SHMEM\_REDUCE\_SYNC\_SIZE}.
+    In \CorCpp, \VAR{pSync} must be an array of elements of type \CTYPE{long}.
+    In \Fortran, \VAR{pSync} must be an array of elements of default integer type.
+    Every element of this array must be initialized with the value
+    \CONST{SHMEM\_SYNC\_VALUE} before any of the \acp{PE} in the active set
+    enter the reduction routine.}
 
 \end{apiarguments}
 

--- a/content/shmem_sync.tex
+++ b/content/shmem_sync.tex
@@ -52,9 +52,9 @@ void shmem_sync(int PE_start, int logPE_stride, int PE_size, long *pSync);
 }
 
 \apinotes{
-    If the \VAR{pSync} array is initialized at run time, be sure to use some type of
-    synchronization, for example, a call to \FUNC{shmem\_sync\_all}, before
-    calling \FUNC{shmem\_sync} for the first time.
+    If the \VAR{pSync} array is initialized at run time, another method of
+    synchronization (e.g., \FUNC{shmem\_sync\_all}) must be used before
+    the initial use of that \VAR{pSync} array by \FUNC{shmem\_sync}.
 
     If the active set does not change, \FUNC{shmem\_sync} can be called
     repeatedly with the same \VAR{pSync} array.  No additional synchronization

--- a/content/shmem_sync.tex
+++ b/content/shmem_sync.tex
@@ -33,8 +33,7 @@ void shmem_sync(int PE_start, int logPE_stride, int PE_size, long *pSync);
 
     As with all \openshmem collective routines, each of these routines assumes
     that only \acp{PE} in the active set call the routine.  If a \ac{PE} not in
-    the active set calls an \openshmem collective routine, undefined behavior
-    results.
+    the active set calls an \openshmem collective routine, the behavior is undefined.
 
     The values of arguments \VAR{PE\_start}, \VAR{logPE\_stride}, and
     \VAR{PE\_size} must be equal on all \acp{PE} in the active set.  The same

--- a/content/shmem_sync.tex
+++ b/content/shmem_sync.tex
@@ -19,7 +19,7 @@ void shmem_sync(int PE_start, int logPE_stride, int PE_size, long *pSync);
 \apiargument{IN}{PE\_size}{The number of \acp{PE} in the active set.
     \VAR{PE\_size} must be of type integer.}
 \apiargument{IN}{pSync}{A symmetric work array. In \CorCpp, \VAR{pSync} must be
-    of type long and size \CONST{SHMEM\_BARRIER\_SYNC\_SIZE}.  Every element of
+    of type \CTYPE{long} and size \CONST{SHMEM\_BARRIER\_SYNC\_SIZE}.  Every element of
     this array must be initialized to \CONST{SHMEM\_SYNC\_VALUE} before any of the
     \acp{PE} in the active set enter \FUNC{shmem\_sync} the first time.}
 

--- a/content/shmem_sync.tex
+++ b/content/shmem_sync.tex
@@ -45,7 +45,7 @@ void shmem_sync(int PE_start, int logPE_stride, int PE_size, long *pSync);
     completion of remote memory updates issued via \openshmem routines.
 
     The same \VAR{pSync} array may be reused on consecutive calls to
-    \FUNC{shmem\_sync} if the same active \ac{PE} set is used.
+    \FUNC{shmem\_sync} if the same active set is used.
 }
 
 \apireturnvalues{

--- a/content/shmem_sync.tex
+++ b/content/shmem_sync.tex
@@ -71,7 +71,7 @@ void shmem_sync(int PE_start, int logPE_stride, int PE_size, long *pSync);
 
 \apicexample
     {The following \FUNC{shmem\_sync\_all} and \FUNC{shmem\_sync} example is
-    for \CorCpp programs:}
+    for \Cstd[11] programs:}
     {./example_code/shmem_sync_example.c}
     {}
 


### PR DESCRIPTION
This PR includes the post-RC1 changes that I identified in my review. Some of these were noted in the RCM discussion, others were not.

I tried to structure the commits in case you, as section chair, wanted some of them but not others.

Commit f944717 in this PR also should take the place of https://github.com/manjugv/specification/pull/8.