### PR TITLE
setup: delete inappropriate uses of hybrid programs

### DIFF
--- a/content/shmem_addr_accessible.tex
+++ b/content/shmem_addr_accessible.tex
@@ -32,15 +32,7 @@ int @\FuncDecl{shmem\_addr\_accessible}@(const void *addr, int pe);
 }
 
 \apinotes{
-    This routine may be particularly useful for hybrid programming with other
-    communication libraries (such as \ac{MPI}) or parallel languages.  For
-    example, when an \ac{MPI} job uses \ac{MPMD} mode, multiple executable
-    \ac{MPI} programs may use \openshmem routines.  In such cases, static
-    memory, such as a \Cstd global variable, is
-    symmetric between processes running from the same executable file, but is
-    not symmetric between processes running from different executable files.
-    Data allocated from the symmetric heap (e.g., using \FUNC{shmem\_malloc})
-    is symmetric across the same or different executable files.
+    None.
 }
 
 \end{apidefinition}

--- a/content/shmem_pe_accessible.tex
+++ b/content/shmem_pe_accessible.tex
@@ -29,14 +29,7 @@ int @\FuncDecl{shmem\_pe\_accessible}@(int pe);
 }
 
 \apinotes{
-    This routine may be particularly useful for hybrid programming with other
-    communication libraries (such as \ac{MPI}) or parallel languages.  For
-    example, when an \ac{MPI} job uses \ac{MPMD} mode, multiple executable
-    \ac{MPI} programs are executed as part of the same MPI job.  In such cases,
-    \openshmem support may only be available between processes running from the
-    same executable file.  In addition, some environments may allow a hybrid
-    job to span multiple network partitions.  In such scenarios, \openshmem
-    support may only be available between \acp{PE} within the same partition.
+    None.
 }
 
 \end{apidefinition}


### PR DESCRIPTION
The notes for `shmem_pe_accessible` and `shmem_addr_accessible` have several issues as described below. Thus, I'd suggest we delete these notes.

- shmem_pe_accessible:
```
...when an MPI job uses Multiple Program Multiple Data (MPMD) mode, 
multiple executable MPI programs are executed as part of the same MPI job. 
In such cases, OpenSHMEM support may only be available between processes 
running from the same executable file.
```
In a hybrid program, only processes that have initialized SHMEM can have valid PE numbers, and thus can be checked by `shmem_pe_accessible`.

```
In addition, some environments may allow a hybrid job to span multiple network partitions. 
In such scenarios, OpenSHMEM support may only be available between PEs within the 
same partition.
```
Same issue here, it is unclear how we can specify the PE of a remote process that exists in a different network partition. E.g., the PE numbering of two partitions can be {0,1,2} + {0,1,2}, or {0,1,2} + {3,4,5}. If P0 in the first partition checks the accessibility of a process in the second partition, the result is always TRUE in the former case.

- shmem_addr_accessible
```
...when an MPI job uses MPMD mode, multiple executable MPI programs may use OpenSHMEM 
routines. In such cases, static memory, such as a C global variable, is symmetric between 
processes running from the same executable file, but is not symmetric between processes 
running from different executable files....
```
It is unclear how we can specify the SHMEM PE of a process that initializes only MPI.